### PR TITLE
Fix to release build action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,26 +49,11 @@ jobs:
           name: Build
           path: build
 
-      - name: Upload WebGL Build folder
-        if: matrix.targetPlatform == 'WebGL'
-        run: |
-          mv build/WebGL/WebGL ../
-          git config --local user.email "${{ secrets.USER_EMAIL }}"
-          git config --local user.name "${{ secrets.USER_NAME }}"
-          git checkout -b gh-pages origin/gh-pages
-          rm -rf ./*
-          cp -pr ../WebGL/* ./
-          git add .
-          git commit -m "FriedAmida update"
-
-      - uses: ad-m/github-push-action@v0.5.0
+      - uses: peaceiris/actions-gh-pages@v3.5.7
         if: matrix.targetPlatform == 'WebGL'
         with:
-          github_token: ${{ secrets.USER_PAT }}
-          branch: 'gh-pages'
-          force: true
-          directory: '.'
-          repository: 'koob1999/FriedAmida'
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./build/WebGL/WebGL
 
       - uses: 8398a7/action-slack@v3.0.0
         if: success() && matrix.targetPlatform == 'WebGL'


### PR DESCRIPTION
## 概要
- buildフォルダの退避先を階層が一つ上のフォルダにしていたのですが、権限がないらしくビルドが失敗してしまってました
- そもそも退避せずに解決可能でしたので、修正しました

## 詳細
- アクションを利用して、`gh-pages`にデプロイするようにしました