### PR TITLE
Refactor to remove game manager from stage generater

### DIFF
--- a/Assets/Scenes/Main.unity
+++ b/Assets/Scenes/Main.unity
@@ -282,7 +282,7 @@ RectTransform:
   - {fileID: 1961759893}
   - {fileID: 1140753673}
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -402,6 +402,7 @@ MonoBehaviour:
   calorieMob: {fileID: 990452483863180522, guid: 9e3ea8cc5de3f614fb373b0c1507d38e,
     type: 3}
   enemyGeneratePlace: {fileID: 1704372097}
+  stageGenerater: {fileID: 852684520}
 --- !u!4 &235228152
 Transform:
   m_ObjectHideFlags: 0
@@ -414,6 +415,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1704372098}
+  - {fileID: 852684521}
   m_Father: {fileID: 658604814}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -903,12 +905,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 852684519}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_Father: {fileID: 235228152}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &947819756
 GameObject:
@@ -1775,7 +1777,7 @@ Transform:
   m_LocalScale: {x: 1.5484264, y: 1.5484264, z: 1.5484264}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1881204892
 GameObject:
@@ -1969,7 +1971,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2057730658
 GameObject:

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -20,8 +20,6 @@ public class GameManager : MonoBehaviour
 	[SerializeField] Text minuteText;
 	[SerializeField] Text secandText;
 
-	[System.NonSerialized] public List<Oil> Oils;
-	[System.NonSerialized] public List<Trash> Trashes;
 	GameObject currentEnemyObj;//現在戦闘中の敵
 	Customer currentCustomer;//●変数名微妙●
 
@@ -37,11 +35,7 @@ public class GameManager : MonoBehaviour
 		{
 			isRush = value;
 			itemGenerater.IsRush = isRush;
-			//●もっときれいにやりたい●
-			foreach(Trash trash in Trashes)
-			{
-				trash.ChangeOil(value);
-			}
+			stageManager.ChangeTrashToOil(isRush);
 			//BGM変更
 			//ゲーム速度少し上昇
 			//制限時間停止
@@ -114,15 +108,7 @@ public class GameManager : MonoBehaviour
 	// Start is called before the first frame update
 	void Start()
     {
-		foreach (Oil oil in Oils)
-		{
-			oil.CompletedFriedFoodAction = CompletedFriedFood;
-		}
-
-		foreach(Trash trash in Trashes)
-		{
-			trash.CompletedFriedFoodAction = CompletedFriedFood;
-		}
+		stageManager.SetCompletedActionToOil(CompletedFriedFood);
 
 		stageManager.UpdateRemainLinesText = text =>
 		{

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -48,9 +48,6 @@ public class GameManager : MonoBehaviour
 		}
 	}
 
-	//●Playerクラスに分ける可能性あり●
-	const int MaxDrawLineNum = 3;
-
 	const float RushTime = 20;
 	const int MaxRushGage = 1;
 	int rushGage;
@@ -93,29 +90,6 @@ public class GameManager : MonoBehaviour
 		}
 	}
 
-	int remainLines = MaxDrawLineNum;
-	public int RemainLines
-	{
-		get { return remainLines; }
-
-		set
-		{
-			if (value > MaxDrawLineNum)
-			{
-				remainLines = MaxDrawLineNum;
-			}
-			else if (value < 0)
-			{
-				remainLines = 0;
-			}
-			else
-			{
-				remainLines = value;
-			}
-			remainLinesText.text = "残り本数" + RemainLines.ToString() + "/" + MaxDrawLineNum.ToString();
-		}
-	}
-
 	int combo = 0;
 	public int Combo
 	{
@@ -149,6 +123,11 @@ public class GameManager : MonoBehaviour
 		{
 			trash.CompletedFriedFoodAction = CompletedFriedFood;
 		}
+
+		stageManager.UpdateRemainLinesText = text =>
+		{
+			remainLinesText.text = text;
+		};
 
 		StartCoroutine(CountTime());
 

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -24,7 +24,6 @@ public class GameManager : MonoBehaviour
 	[System.NonSerialized] public List<Trash> Trashes;
 	GameObject currentEnemyObj;//現在戦闘中の敵
 	Customer currentCustomer;//●変数名微妙●
-	[System.NonSerialized] public HorizontalLine[,] AmidaLines;
 
 	[SerializeField] int limitTime;
 	bool IsTimeOver => limitTime <= 0;
@@ -247,15 +246,7 @@ public class GameManager : MonoBehaviour
 		{
 			currentCustomer.DoAction();
 		}
-
-		//あみだのリセット
-		for (int i = 0; i < AmidaLines.GetLength(0); i++)
-		{
-			for (int j = 0; j < AmidaLines.GetLength(1); j++)
-			{
-				AmidaLines[i, j].SetOnObjActivation(false);
-			}
-		}
+		stageManager.ResetAmidaLines();
 	}
 
 	void ClearGame()

--- a/Assets/Scripts/StageGenerater.cs
+++ b/Assets/Scripts/StageGenerater.cs
@@ -71,9 +71,9 @@ public class StageGenerater : MonoBehaviour
 												new Vector3(minXPos + (xInterval * i) + 1, maxYPos - ((yInterval * j) + (i % 2 * yInterval / 2)) - 1, 0),
 												Quaternion.identity).GetComponent<HorizontalLine>();
 
-				amidaLines[i, j].MinusRemainLinesAction = () => { gameManager.RemainLines--; };
-				amidaLines[i, j].PlusRemainLinesAction = () => { gameManager.RemainLines++; };
-				amidaLines[i, j].IsDrawLineAction = () => { return gameManager.RemainLines > 0; };
+				amidaLines[i, j].MinusRemainLinesAction = () => { stageManager.RemainLines--; };
+				amidaLines[i, j].PlusRemainLinesAction = () => { stageManager.RemainLines++; };
+				amidaLines[i, j].IsDrawLineAction = () => { return stageManager.RemainLines > 0; };
 
 			}
 		}

--- a/Assets/Scripts/StageGenerater.cs
+++ b/Assets/Scripts/StageGenerater.cs
@@ -35,11 +35,6 @@ public class StageGenerater : MonoBehaviour
 	[SerializeField] FoodGenerater foodGenerater;
 	[SerializeField] ItemGenerater itemGenerater;
 
-	private void Awake()
-	{
-		GenerateStage();
-	}
-
 	// Start is called before the first frame update
 	void Start()
     {
@@ -52,7 +47,7 @@ public class StageGenerater : MonoBehaviour
         
     }
 
-	void GenerateStage()
+	public void GenerateStage(StageManager stageManager)
 	{
 		float xLength = maxXPos - minXPos;
 		float xInterval = 2;
@@ -84,7 +79,7 @@ public class StageGenerater : MonoBehaviour
 		}
 
 		lineCursol.AmidaLines = amidaLines;
-		gameManager.AmidaLines = amidaLines;
+		stageManager.AmidaLines = amidaLines;
 
 		//▼油の生成
 		List<Oil> oils = new List<Oil>();

--- a/Assets/Scripts/StageGenerater.cs
+++ b/Assets/Scripts/StageGenerater.cs
@@ -31,7 +31,6 @@ public class StageGenerater : MonoBehaviour
 	float minYPos = -3;
 	//参照パス
 	[SerializeField] LineCursol lineCursol;
-	[SerializeField] GameManager gameManager;
 	[SerializeField] FoodGenerater foodGenerater;
 	[SerializeField] ItemGenerater itemGenerater;
 

--- a/Assets/Scripts/StageGenerater.cs
+++ b/Assets/Scripts/StageGenerater.cs
@@ -103,8 +103,8 @@ public class StageGenerater : MonoBehaviour
 			}
 		}
 
-		gameManager.Oils = oils;
-		gameManager.Trashes = trashes;
+		stageManager.Oils = oils;
+		stageManager.Trashes = trashes;
 
 		//▼食材生成場所の生成
 		//ここGameObjectよりVector３で渡したほうが良い

--- a/Assets/Scripts/StageManager.cs
+++ b/Assets/Scripts/StageManager.cs
@@ -20,6 +20,8 @@ public class StageManager : MonoBehaviour
 	[SerializeField] GameObject nomalMob;//敵のPrefab設定用
 	[SerializeField] GameObject calorieMob;
 	[SerializeField] GameObject enemyGeneratePlace;//敵の生成場所設定場所
+	[SerializeField] StageGenerater stageGenerater;
+	[System.NonSerialized] public HorizontalLine[,] AmidaLines;
 
 	int presentEnemyNum;//現在現れている敵が何番目か
 	public int PresentEnemyNum
@@ -36,7 +38,8 @@ public class StageManager : MonoBehaviour
     // Start is called before the first frame update
     void Start()
     {
-    }
+		stageGenerater.GenerateStage(this);
+	}
 
     // Update is called once per frame
     void Update()
@@ -85,5 +88,17 @@ public class StageManager : MonoBehaviour
 	public bool IsLastEnemy()
 	{
 		return PresentEnemyNum == enemies.Length - 1;
+	}
+
+	public void ResetAmidaLines()
+	{
+		//あみだのリセット
+		for (int i = 0; i < AmidaLines.GetLength(0); i++)
+		{
+			for (int j = 0; j < AmidaLines.GetLength(1); j++)
+			{
+				AmidaLines[i, j].SetOnObjActivation(false);
+			}
+		}
 	}
 }

--- a/Assets/Scripts/StageManager.cs
+++ b/Assets/Scripts/StageManager.cs
@@ -22,6 +22,8 @@ public class StageManager : MonoBehaviour
 	[SerializeField] GameObject calorieMob;
 	[SerializeField] GameObject enemyGeneratePlace;//敵の生成場所設定場所
 	[SerializeField] StageGenerater stageGenerater;
+	[System.NonSerialized] public List<Oil> Oils;
+	[System.NonSerialized] public List<Trash> Trashes;
 	[System.NonSerialized] public HorizontalLine[,] AmidaLines;
 
 	int presentEnemyNum;//現在現れている敵が何番目か
@@ -126,6 +128,28 @@ public class StageManager : MonoBehaviour
 			{
 				AmidaLines[i, j].SetOnObjActivation(false);
 			}
+		}
+	}
+
+	public void SetCompletedActionToOil(Oil.CompletedFriedFoodDelegate completedFriedFood)
+	{
+		foreach (Oil oil in Oils)
+		{
+			oil.CompletedFriedFoodAction = completedFriedFood;
+		}
+
+		foreach (Trash trash in Trashes)
+		{
+			trash.CompletedFriedFoodAction = completedFriedFood;
+		}
+	}
+
+	public void ChangeTrashToOil(bool isRush)
+	{
+		//●もっときれいにやりたい●
+		foreach (Trash trash in Trashes)
+		{
+			trash.ChangeOil(isRush);
 		}
 	}
 }

--- a/Assets/Scripts/StageManager.cs
+++ b/Assets/Scripts/StageManager.cs
@@ -22,9 +22,9 @@ public class StageManager : MonoBehaviour
 	[SerializeField] GameObject calorieMob;
 	[SerializeField] GameObject enemyGeneratePlace;//敵の生成場所設定場所
 	[SerializeField] StageGenerater stageGenerater;
-	[System.NonSerialized] public List<Oil> Oils;
-	[System.NonSerialized] public List<Trash> Trashes;
-	[System.NonSerialized] public HorizontalLine[,] AmidaLines;
+	[NonSerialized] public List<Oil> Oils;
+	[NonSerialized] public List<Trash> Trashes;
+	[NonSerialized] public HorizontalLine[,] AmidaLines;
 
 	int presentEnemyNum;//現在現れている敵が何番目か
 	public int PresentEnemyNum

--- a/Assets/Scripts/StageManager.cs
+++ b/Assets/Scripts/StageManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
@@ -35,11 +36,37 @@ public class StageManager : MonoBehaviour
 		}
 	}
 
+	//●Playerクラスに分ける可能性あり●
+	const int MaxDrawLineNum = 3;
+	public Action<string> UpdateRemainLinesText;
+	int remainLines = MaxDrawLineNum;
+	public int RemainLines
+	{
+		get { return remainLines; }
+
+		set
+		{
+			if (value > MaxDrawLineNum)
+			{
+				remainLines = MaxDrawLineNum;
+			}
+			else if (value < 0)
+			{
+				remainLines = 0;
+			}
+			else
+			{
+				remainLines = value;
+			}
+			UpdateRemainLinesText("残り本数" + RemainLines.ToString() + "/" + MaxDrawLineNum.ToString());
+		}
+	}
+
     // Start is called before the first frame update
     void Start()
     {
 		stageGenerater.GenerateStage(this);
-	}
+    }
 
     // Update is called once per frame
     void Update()


### PR DESCRIPTION
## 概要
- StageGeneraterがいろいろなクラスを持っているため、まずはGameManagerを削除する

## 備考
- `AmidaLines` `Oils` `Trashes`のアクセス修飾子が`public`のままですが #46 で対応予定です

## issue
- Fix #47