### PR TITLE
SceneChangerを静的クラスから動的クラスに変更

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -220,7 +220,8 @@ public class GameManager : MonoBehaviour
 		//８：スコア表示等
 
 		//9：次のステージへ
-		SceneChanger.MoveNextStage();
+		SceneChanger sceneChanger = new SceneChanger();
+		sceneChanger.MoveNextStage();
 	}
 
 	void RushEnd()

--- a/Assets/Scripts/SceneChanger.cs
+++ b/Assets/Scripts/SceneChanger.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
-public static class SceneChanger
+public class SceneChanger
 {
-	public static void MoveNextStage()
+	public void MoveNextStage()
 	{
 		switch (SceneManager.GetActiveScene().name)
 		{


### PR DESCRIPTION
### 概要

- Unityのボタン機能は静的メソッドを直接呼び出すことができなかったので、ボタンでこのクラスを使用するためにSceneChangerを静的クラスから動的クラスに変更しました