### PR TITLE
同じレーンから食材が流れるバグの修正

### DIFF
--- a/Assets/Scripts/ArrayExtensions.cs
+++ b/Assets/Scripts/ArrayExtensions.cs
@@ -4,25 +4,18 @@ using UnityEngine;
 
 public static class ArrayExtensions
 {
-	/// <summary>
-	/// 第二引数分だけ第一引数の配列からランダム、重複なしで値を抽出した配列を返す
-	/// </summary>
-	/// <typeparam name="Type"></typeparam>
-	/// <param name="types"></param>
-	/// <param name="num"></param>
-	/// <returns></returns>
-	public static T[] Shuffle<T>(this T[] types, int num)
+
+	//配列をシャッフルする
+	public static void Shuffle<T>(this T[] types)
 	{
-		T[] returnTypes = new T[num];
-
-		for (int i = 0, len = types.Length; i < num; i++, len--)
+		for (int i = 0; i < types.Length * 10; i++) 
 		{
-			int rand = Random.Range(0, len);
+			int rand1 = Random.Range(0, types.Length);
+			int rand2 = Random.Range(0, types.Length);
 
-			returnTypes[i] = types[rand];
-			types[rand] = types[len - 1];
+			T temp = types[rand1];
+			types[rand1] = types[rand2];
+			types[rand2] = temp;
 		}
-
-		return returnTypes;
 	}
 }

--- a/Assets/Scripts/ArrayExtensions.cs
+++ b/Assets/Scripts/ArrayExtensions.cs
@@ -1,6 +1,8 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using System.Linq;
+using System;
 
 public static class ArrayExtensions
 {
@@ -8,14 +10,11 @@ public static class ArrayExtensions
 	//配列をシャッフルする
 	public static void Shuffle<T>(this T[] types)
 	{
-		for (int i = 0; i < types.Length * 10; i++) 
+		T[] types2 = types.OrderBy(i => Guid.NewGuid()).ToArray();
+	
+		for(int i=0; i < types.Length; i++)
 		{
-			int rand1 = Random.Range(0, types.Length);
-			int rand2 = Random.Range(0, types.Length);
-
-			T temp = types[rand1];
-			types[rand1] = types[rand2];
-			types[rand2] = temp;
+			types[i] = types2[i];
 		}
 	}
 }

--- a/Assets/Scripts/ArrayExtensions.cs
+++ b/Assets/Scripts/ArrayExtensions.cs
@@ -8,13 +8,8 @@ public static class ArrayExtensions
 {
 
 	//配列をシャッフルする
-	public static void Shuffle<T>(this T[] types)
+	public static T[] Shuffle<T>(this T[] types)
 	{
-		T[] types2 = types.OrderBy(i => Guid.NewGuid()).ToArray();
-	
-		for(int i=0; i < types.Length; i++)
-		{
-			types[i] = types2[i];
-		}
+		return types.OrderBy(i => Guid.NewGuid()).ToArray();
 	}
 }

--- a/Assets/Scripts/FoodGenerater.cs
+++ b/Assets/Scripts/FoodGenerater.cs
@@ -32,10 +32,10 @@ public class FoodGenerater : MonoBehaviour
 		GameObject[] createdObjs = new GameObject[foodTypes.Length];
 
 		//1:引数分食材を生成
-		GeneratePlaces.Shuffle();
+		GameObject[] generatePlaces = GeneratePlaces.Shuffle();
 		for(int i = 0; i < foodTypes.Length; i++)
 		{
-			createdObjs[i] = FoodGenerate(foodTypes[i], GeneratePlaces[i].transform.position);
+			createdObjs[i] = FoodGenerate(foodTypes[i], generatePlaces[i].transform.position);
 		}
 		//x軸を元にソート
 		Array.Sort(createdObjs, (obj1, obj2) =>

--- a/Assets/Scripts/FoodGenerater.cs
+++ b/Assets/Scripts/FoodGenerater.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using Amida;
@@ -10,7 +11,7 @@ public class FoodGenerater : MonoBehaviour
 	[SerializeField] GameObject pork;
 	[SerializeField] GameObject shrimp;
 
-	[System.NonSerialized] public GameObject[] GeneratePlaces;
+	[NonSerialized] public GameObject[] GeneratePlaces;
 	[SerializeField] int generateSpan;
 
     // Start is called before the first frame update
@@ -37,7 +38,7 @@ public class FoodGenerater : MonoBehaviour
 			createdObjs[i] = FoodGenerate(foodTypes[i], GeneratePlaces[i].transform.position);
 		}
 		//x軸を元にソート
-		System.Array.Sort(createdObjs, (obj1, obj2) =>
+		Array.Sort(createdObjs, (obj1, obj2) =>
 			{
 				if (obj1.transform.position.x > obj2.transform.position.x)
 				{

--- a/Assets/Scripts/FoodGenerater.cs
+++ b/Assets/Scripts/FoodGenerater.cs
@@ -31,11 +31,27 @@ public class FoodGenerater : MonoBehaviour
 		GameObject[] createdObjs = new GameObject[foodTypes.Length];
 
 		//1:引数分食材を生成
-		GameObject[] generatePlaces = GeneratePlaces.Shuffle(foodTypes.Length);
+		GeneratePlaces.Shuffle();
 		for(int i = 0; i < foodTypes.Length; i++)
 		{
-			createdObjs[i] = FoodGenerate(foodTypes[i], generatePlaces[i].transform.position);
+			createdObjs[i] = FoodGenerate(foodTypes[i], GeneratePlaces[i].transform.position);
 		}
+		//x軸を元にソート
+		System.Array.Sort(createdObjs, (obj1, obj2) =>
+			{
+				if (obj1.transform.position.x > obj2.transform.position.x)
+				{
+					return 1;
+				}
+				else if(obj1.transform.position.x < obj2.transform.position.x)
+				{
+					return -1;
+				}
+				else
+				{
+					return 0;
+				}
+			});
 		//2:左から順にアニメーションを再生
 		StartCoroutine(AnimateFoodCoroutine(createdObjs));
 	}


### PR DESCRIPTION
### 概要

- Shuffle関数を単純に配列をシャッフルする関数に変更

- 左から順に食材が流れていなかったのでその処理を追加
### 備考

- fixed #50 