### PR TITLE
よこに食材が進み続けるバグの修正

### DIFF
--- a/Assets/Scripts/HorizontalLine.cs
+++ b/Assets/Scripts/HorizontalLine.cs
@@ -47,7 +47,7 @@ public class HorizontalLine : MonoBehaviour
 		return OnObj.activeSelf;
 	}
 
-	private void OnTriggerEnter2D(Collider2D collision)
+	private void OnTriggerStay2D(Collider2D collision)
 	{
 		if (collision.gameObject.tag == "food")
 		{


### PR DESCRIPTION
### 概要

- 食材が複数個同時にあみだの横線を通っている場合、片方だけが横線を通り過ぎたとき横線を消すことができるバグの修正