### PR TITLE
Fix target platform for unity builder

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
         unityVersion:
           - 2018.4.20f1
         targetPlatform:
-          - StandaloneWindows64
+          - Android
           - WebGL
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         unityVersion:
           - 2018.4.20f1
         targetPlatform:
-          - StandaloneWindows64
+          - Android
           - WebGL
 
     steps:


### PR DESCRIPTION
## 概要
- Windows用のビルドからAndroid用のビルドに変更しました

## 備考
- コントローラーが用意できずデバッグが難しいため、大会にWindowsゲームではなくAndroidアプリとして提出する